### PR TITLE
refactor: improve thread safety

### DIFF
--- a/src/main/java/com/ttsplugin/main/Dialog.java
+++ b/src/main/java/com/ttsplugin/main/Dialog.java
@@ -1,13 +1,15 @@
 package com.ttsplugin.main;
 
+import lombok.Value;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.util.Text;
 
+@Value
 public class Dialog {
-	public String message;
-	public String sender;
+	String message;
+	String sender;
 	
 	public Dialog(String message, String sender) {
 		this.message = Text.sanitizeMultilineText(
@@ -42,15 +44,5 @@ public class Dialog {
 	
 	private static boolean isVisible(Widget widget) {
 		return widget != null && !widget.isHidden();
-	}
-	
-	@Override
-	public boolean equals(Object other2) {
-		if (other2 == null) {
-			return false;
-		}
-		
-		Dialog other = (Dialog)other2;
-		return this.message.equals(other.message) && this.sender.equals(other.sender);
 	}
 }

--- a/src/main/java/com/ttsplugin/main/TTSMessage.java
+++ b/src/main/java/com/ttsplugin/main/TTSMessage.java
@@ -1,14 +1,10 @@
 package com.ttsplugin.main;
 
+import lombok.Value;
+
+@Value
 public class TTSMessage {
-	public String message;
-	public int voice, distance;
-	public long time;
-	
-	public TTSMessage(String message, int voice, int distance, long time) {
-		this.message = message;
-		this.voice = voice;
-		this.distance = distance;
-		this.time = time;
-	}
+	String message;
+	int voice, distance;
+	long time;
 }

--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -113,7 +113,7 @@ public class TTSPlugin extends Plugin {
 		Future<?> future = executor.scheduleWithFixedDelay(() -> {
 			TTSMessage message;
 			while ((message = queue.poll()) != null) {
-				if ((double) Math.abs(message.time - System.currentTimeMillis()) / (double) 1000 <= this.config.queueSeconds()) {
+				if ((double) Math.abs(message.getTime() - System.currentTimeMillis()) / (double) 1000 <= this.config.queueSeconds()) {
 					play(message);
 				}
 			}
@@ -166,7 +166,7 @@ public class TTSPlugin extends Plugin {
 			if (dialog != null && !dialog.equals(lastDialog)) {
 				Clip current = this.currentClip;
 				if (current != null) current.stop();
-				processMessage(dialog.message, dialog.sender, MessageType.DIALOG);
+				processMessage(dialog.getMessage(), dialog.getSender(), MessageType.DIALOG);
 			}
 			
 			lastDialog = dialog;
@@ -270,7 +270,7 @@ public class TTSPlugin extends Plugin {
 	 */
 	private void play(TTSMessage message) {
 		try {
-			String request = "https://ttsplugin.com?m=" + URLEncoder.encode(message.message, "UTF-8") + "&r=" + config.rate() + "&v=" + message.voice;
+			String request = "https://ttsplugin.com?m=" + URLEncoder.encode(message.getMessage(), "UTF-8") + "&r=" + config.rate() + "&v=" + message.getVoice();
 
 			byte[] bytes;
 			try (InputStream stream = new URL(request).openConnection().getInputStream()) {
@@ -283,7 +283,7 @@ public class TTSPlugin extends Plugin {
 					currentClip = clip;
 
 					if (config.distanceVolume()) {
-						Utils.setClipVolume((config.volume() / (float) 10) - ((float) message.distance / (float) config.distanceVolumeEffect()), clip);
+						Utils.setClipVolume((config.volume() / (float) 10) - ((float) message.getDistance() / (float) config.distanceVolumeEffect()), clip);
 					} else {
 						Utils.setClipVolume(config.volume() / (float) 10, clip);
 					}

--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -1,5 +1,6 @@
 package com.ttsplugin.main;
 
+import com.google.common.io.ByteStreams;
 import com.google.inject.Provides;
 import com.ttsplugin.enums.Gender;
 import com.ttsplugin.enums.MessageType;
@@ -8,13 +9,19 @@ import com.ttsplugin.utils.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Synchronized;
-import net.runelite.api.*;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.MenuAction;
+import net.runelite.api.Player;
+import net.runelite.api.Point;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.NotificationFired;
@@ -33,18 +40,27 @@ import javax.sound.sampled.Clip;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+@Slf4j
 @PluginDescriptor(name = "Text to speech", description = "Text to speech for chat, dialog, menu options and notifications", tags = {"tts", "text", "voice", "chat", "dialog", "speak", "notification"})
 public class TTSPlugin extends Plugin {	
 	private final Map<String, List<Long>> spamHash = new HashMap<>();
-	public List<TTSMessage> queue = new ArrayList<>();
-	public long lastProcess;
-	public Dialog lastDialog;
-	public Clip currentClip;
-	public Thread queueThread;
+	private final BlockingQueue<TTSMessage> queue = new LinkedBlockingQueue<>();
+	private long lastProcess;
+	private Dialog lastDialog;
+	private volatile Clip currentClip;
+	private final AtomicReference<Future<?>> queueTask = new AtomicReference<>();
 
 	@Inject
 	private Client client;
@@ -54,6 +70,9 @@ public class TTSPlugin extends Plugin {
 
 	@Inject
 	private ItemManager itemManager;
+
+	@Inject
+	private ScheduledExecutorService executor;
 
 	@Inject
 	private KeyManager keyManager;
@@ -90,26 +109,16 @@ public class TTSPlugin extends Plugin {
 		this.keyManager.registerKeyListener(this.quantityHotkeyListener);
 		this.mouseManager.registerMouseListener(this.mouseHandler);
 		
-		//New thread for playing messages from queue. this will be terminated when the plugin is disabled
-		queueThread = new Thread(() -> {
-			while(true) {
-				try {
-					List<TTSMessage> queueCopy = new ArrayList<>(this.queue);
-					for (TTSMessage message : queueCopy) {
-						if ((double)Math.abs(message.time - System.currentTimeMillis()) / (double)1000 <= this.config.queueSeconds()) {
-							play(message);
-						}
-						
-						this.queue.remove(message);
-					}
-				} catch (Exception e) {
-					e.printStackTrace();
+		// New task for playing messages from queue. this will be terminated when the plugin is disabled
+		Future<?> future = executor.scheduleWithFixedDelay(() -> {
+			TTSMessage message;
+			while ((message = queue.poll()) != null) {
+				if ((double) Math.abs(message.time - System.currentTimeMillis()) / (double) 1000 <= this.config.queueSeconds()) {
+					play(message);
 				}
-				
-				Utils.sleep(50);
 			}
-		});
-		queueThread.start();
+		}, 50, 50, TimeUnit.MILLISECONDS);
+		queueTask.set(future);
 	}
 
 	@Override
@@ -117,10 +126,17 @@ public class TTSPlugin extends Plugin {
 		this.keyManager.unregisterKeyListener(this.hotkeyListener);
 		this.keyManager.unregisterKeyListener(this.quantityHotkeyListener);
 		this.mouseManager.unregisterMouseListener(this.mouseHandler);
-		
-		//Terminate queue thread
-		queueThread.suspend();
-		queueThread = null;
+
+		lastProcess = 0;
+		lastDialog = null;
+		menuOpenPoint = null;
+		currentClip = null;
+
+		// Terminate queue task
+		queue.clear();
+		Future<?> task = queueTask.getAndSet(null);
+		if (task != null)
+			task.cancel(false);
 	}
 
 	@Provides
@@ -148,7 +164,8 @@ public class TTSPlugin extends Plugin {
 			Dialog dialog = Dialog.getCurrentDialog(client);
 
 			if (dialog != null && !dialog.equals(lastDialog)) {
-				if (currentClip != null) currentClip.stop();
+				Clip current = this.currentClip;
+				if (current != null) current.stop();
 				processMessage(dialog.message, dialog.sender, MessageType.DIALOG);
 			}
 			
@@ -232,13 +249,13 @@ public class TTSPlugin extends Plugin {
 		
 		final int voice2 = voice;
 		final int distance2 = distance;
-		new Thread(() -> {
+		executor.execute(() -> {
 			try {
 				addToQueue(ConvertMessage.convert(message), voice2, distance2);
 			} catch (Exception e) {
-				e.printStackTrace();
+				log.warn("Failed to queue message", e);
 			}
-		}).start();
+		});
 	}
 	
 	/**
@@ -251,43 +268,40 @@ public class TTSPlugin extends Plugin {
 	/**
 	 * Plays the text with the specified voice and distance
 	 */
-	public void play(TTSMessage message) {
+	private void play(TTSMessage message) {
 		try {
 			String request = "https://ttsplugin.com?m=" + URLEncoder.encode(message.message, "UTF-8") + "&r=" + config.rate() + "&v=" + message.voice;
 
-		    URLConnection conn = new URL(request).openConnection();
-		    byte[] bytes = new byte[conn.getContentLength()];
-		    InputStream stream = conn.getInputStream();
-		    for (int i = 0; i < conn.getContentLength(); i++) {
-		    	bytes[i] = (byte)stream.read();
-		    }
-		    
-			AudioInputStream inputStream = AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes));
-			
-			Clip clip = AudioSystem.getClip();
-	        clip.open(inputStream);
-	        currentClip = clip;
-	        
-	        if (config.distanceVolume()) {
-	        	Utils.setClipVolume((config.volume() / (float)10) - ((float)message.distance / (float)config.distanceVolumeEffect()), clip);
-	        } else {
-	        	Utils.setClipVolume(config.volume() / (float)10, clip);
-	        }
-	        
-	        clip.start();
-			Utils.sleep(50);
-			
-			while(clip.isRunning()) {
-				Utils.sleep(50);
-				if (client.getGameState() == GameState.LOGIN_SCREEN || queueThread == null) {
-					clip.stop();
-					break;
-				}
+			byte[] bytes;
+			try (InputStream stream = new URL(request).openConnection().getInputStream()) {
+				bytes = ByteStreams.toByteArray(stream);
 			}
 
-			clip.close();
+			try (AudioInputStream inputStream = AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes))) {
+				try (Clip clip = AudioSystem.getClip()) {
+					clip.open(inputStream);
+					currentClip = clip;
+
+					if (config.distanceVolume()) {
+						Utils.setClipVolume((config.volume() / (float) 10) - ((float) message.distance / (float) config.distanceVolumeEffect()), clip);
+					} else {
+						Utils.setClipVolume(config.volume() / (float) 10, clip);
+					}
+
+					clip.start();
+					do {
+						Utils.sleep(50);
+						if (client.getGameState() == GameState.LOGIN_SCREEN || queueTask.get() == null) {
+							clip.stop();
+							break;
+						}
+					} while (clip.isRunning());
+
+					currentClip = null;
+				}
+			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.warn("Failed to play clip", e);
 		}
 	}
 	
@@ -333,13 +347,13 @@ public class TTSPlugin extends Plugin {
 		return list.size() > config.spamMessages();
 	}
 	
-	public Player getPlayerFromUsername(String username) {
+	private Player getPlayerFromUsername(String username) {
+		String sanitized = Text.sanitize(username);
 		for (Player player : client.getCachedPlayers()) {
-			if (player != null && player.getName() != null && Text.sanitize(player.getName()).equals(Text.sanitize(username))) {
+			if (player != null && player.getName() != null && Text.sanitize(player.getName()).equals(sanitized)) {
 				return player;
 			}
 		}
-		
 		return null;
 	}
 

--- a/src/main/java/com/ttsplugin/utils/Utils.java
+++ b/src/main/java/com/ttsplugin/utils/Utils.java
@@ -4,14 +4,6 @@ import javax.sound.sampled.Clip;
 import javax.sound.sampled.FloatControl;
 
 public class Utils {
-	public static void sleep(int ms) {
-		try {
-			Thread.sleep(ms);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-	
 	public static String toLowerCaseWithFirstUppercase(String text) {
 		String first = text.substring(0, 1).toUpperCase();
 		return first + text.toLowerCase().substring(1);


### PR DESCRIPTION
* Make `queue` usage thread-safe
* Make `currentClip` usage thread-safe
* Switch `Thread` to `Executor`/`Future` (avoid [deprecated](https://docs.oracle.com/javase/8/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html) `Thread#suspend` call)
* Speed up reading of `InputStream` in `#play` by reading blocks rather than single byte's (and avoid potential resource leaks)
* Improve OOP style for `Dialog`/`TTSMessage`
* Avoid `Thread.sleep`