### PR TITLE
fix: ensure clip queue resumes if line listener was lost

### DIFF
--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -114,10 +114,8 @@ public class TTSPlugin extends Plugin {
 				if (jacoPlayer.isPlaying()) {
 					return;
 				} else {
-					// noinspection SynchronizeOnNonFinalField
-					synchronized (jacoPlayer) {
-						jacoPlayer.getPlayList().clear();
-					}
+					jacoPlayer.stop();
+					jacoPlayer.getPlayList().clear();
 				}
 			}
 
@@ -141,13 +139,13 @@ public class TTSPlugin extends Plugin {
 		lastProcess = 0;
 		lastDialog = null;
 		menuOpenPoint = null;
-		stopClip();
 
 		// Terminate queue task
 		queue.clear();
 		Future<?> task = queueTask.getAndSet(null);
 		if (task != null)
 			task.cancel(false);
+		stopClip();
 	}
 
 	@Provides
@@ -203,7 +201,7 @@ public class TTSPlugin extends Plugin {
 	public void onGameStateChanged(GameStateChanged event) {
 		if (event.getGameState() == GameState.LOGIN_SCREEN) {
 			queue.clear();
-			stopClip();
+			executor.execute(this::stopClip);
 		}
 	}
 
@@ -370,12 +368,9 @@ public class TTSPlugin extends Plugin {
 			clip.close();
 		}
 
-		if (jacoPlayer != null) {
-			// noinspection SynchronizeOnNonFinalField
-			synchronized (jacoPlayer) {
-				jacoPlayer.stop();
-				jacoPlayer.getPlayList().clear();
-			}
+		if (jacoPlayer != null && jacoPlayer.isPlaying()) {
+			jacoPlayer.stop();
+			jacoPlayer.getPlayList().clear();
 		}
 	}
 	

--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -328,8 +328,11 @@ public class TTSPlugin extends Plugin {
 
 			try (AudioInputStream inputStream = AudioSystem.getAudioInputStream(new ByteArrayInputStream(bytes))) {
 				Clip clip = AudioSystem.getClip();
+				if (!currentClip.compareAndSet(null, clip)) {
+					clip.close();
+					return;
+				}
 				clip.open(inputStream);
-				currentClip.set(clip);
 
 				if (config.distanceVolume()) {
 					Utils.setClipVolume((config.volume() / (float) 10) - ((float) message.getDistance() / (float) config.distanceVolumeEffect()), clip);

--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -95,7 +95,7 @@ public class TTSPlugin extends Plugin {
 		this.keyManager.registerKeyListener(this.hotkeyListener);
 		this.keyManager.registerKeyListener(this.quantityHotkeyListener);
 		this.mouseManager.registerMouseListener(this.mouseHandler);
-		
+
 		// New task for playing messages from queue. this will be terminated when the plugin is disabled
 		Future<?> future = executor.scheduleWithFixedDelay(() -> {
 			Clip clip = currentClip.get();
@@ -106,8 +106,8 @@ public class TTSPlugin extends Plugin {
 					clip.close();
 					if (!currentClip.compareAndSet(clip, null)) {
 						return;
-          }
-        }
+					}
+				}
 			}
 
 			if (jacoPlayer != null) {
@@ -119,7 +119,7 @@ public class TTSPlugin extends Plugin {
 						jacoPlayer.getPlayList().clear();
 					}
 				}
-      }
+			}
 
 			TTSMessage message;
 			while ((message = queue.poll()) != null) {

--- a/src/main/java/com/ttsplugin/main/TTSPlugin.java
+++ b/src/main/java/com/ttsplugin/main/TTSPlugin.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
-import javax.sound.sampled.LineEvent;
 import javax.swing.*;
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -337,13 +336,6 @@ public class TTSPlugin extends Plugin {
 				} else {
 					Utils.setClipVolume(config.volume() / (float) 10, clip);
 				}
-
-				clip.addLineListener(event -> {
-					LineEvent.Type type = event.getType();
-					if (type == LineEvent.Type.STOP) {
-						currentClip.compareAndSet(clip, null);
-					}
-				});
 
 				clip.start();
 			}


### PR DESCRIPTION
Closes #26
Closes #27

There may be an edge case (perhaps in the jdk itself) where `LineEvent.Type.STOP` is not fired, so `currentClip` wasn't cleared, which prevented further TTS messages from playing (though I haven't been able to replicate this issue on JDK 17+). 

Now, if `currentClip` isn't null but has completed, we allow further TTS messages to play (and clean up the zombie clip)
